### PR TITLE
Replace header logo with Playgen Birthday branding

### DIFF
--- a/assets/logo-playgen-birthday.svg
+++ b/assets/logo-playgen-birthday.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 180">
+  <rect x="20" y="60" width="160" height="110" rx="24" fill="#1E64B5"/>
+  <path d="M110 115 85 95 85 145Z" fill="#ffffff"/>
+  <path d="M130 115 105 95 105 145Z" fill="#ffffff" opacity="0.75"/>
+  <path d="M100 25c0-19.3-15.7-35-35-35s-35 15.7-35 35c0 12.3 6.6 23.1 17.2 29.1l17.8 9.9 17.8-9.9C93.4 48.1 100 37.3 100 25Z" fill="#F6A333"/>
+  <path d="M82.5 56.5h5a12 12 0 0 1 12 12V80a12 12 0 0 1-12 12h-5a12 12 0 0 1-12-12V68.5a12 12 0 0 1 12-12Z" fill="#F6A333"/>
+  <path d="M146 24.5c0-12 9.7-21.7 21.7-21.7 12 0 21.7 9.7 21.7 21.7 0 7.9-4.2 15.1-11 19.1l-11.6 6.4-11.6-6.4c-6.8-4-11-11.2-11-19.1Z" fill="#F6A333"/>
+  <path d="M168.5 64.3c0-6.8 5.5-12.3 12.3-12.3s12.3 5.5 12.3 12.3-5.5 12.3-12.3 12.3-12.3-5.5-12.3-12.3Z" fill="#F6A333"/>
+  <path d="M206.3 28.4 210.9 38 221 38.6 212.9 45.3 215.5 55 206.3 49.7 197 55l2.6-9.7-8.1-6.7 10.1-.6 4.6-9.6Z" fill="#F6A333"/>
+  <text x="210" y="90" fill="#1E64B5" font-family="'Montserrat', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="48" font-weight="700" letter-spacing="1">PLAYGEN</text>
+  <text x="210" y="138" fill="#F6A333" font-family="'Montserrat', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="48" font-weight="700" letter-spacing="1">BIRTHDAY</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -43,12 +43,8 @@
       border-bottom:1px solid rgba(255,255,255,.06);
     }
     .nav{display:flex;align-items:center;justify-content:space-between;padding:14px 0}
-    .brand{display:flex;align-items:center;gap:12px;font-weight:800;letter-spacing:.4px}
-    .logo{
-      width:40px;height:40px;border-radius:12px;
-      background: conic-gradient(from 180deg, var(--accent), var(--accent2), var(--accent));
-      box-shadow: 0 8px 24px rgba(124,92,255,.45), inset 0 0 18px rgba(255,255,255,.2);
-    }
+    .brand{display:flex;align-items:center;gap:16px;font-weight:800;letter-spacing:.4px}
+    .logo-image{height:54px;width:auto;display:block}
     .actions{display:flex;gap:10px;align-items:center}
     .btn{
       display:inline-flex;align-items:center;justify-content:center;gap:8px;
@@ -130,11 +126,7 @@
   <header>
     <div class="container nav">
       <div class="brand">
-        <div class="logo" aria-hidden="true"></div>
-        <div>
-          <div style="font-size:14px;color:var(--muted);font-weight:700;letter-spacing:.08em">AI PRANK</div>
-          <div style="font-size:18px;font-weight:900;">VIDEO ČESTITKE</div>
-        </div>
+        <img src="assets/logo-playgen-birthday.svg" alt="Playgen Birthday" class="logo-image" />
       </div>
       <div class="actions">
         <a href="#kategorije" class="btn">Kategorije</a>


### PR DESCRIPTION
## Summary
- replace the header branding block with the provided Playgen Birthday logo
- add the Playgen Birthday SVG asset and update spacing to suit the new image

## Testing
- not run (static HTML change)

------
https://chatgpt.com/codex/tasks/task_e_68d3e2ea58408327be0690d06dcf2270