### PR TITLE
Fix SVG viewBox to avoid logo clipping

### DIFF
--- a/assets/logo-playgen-birthday.svg
+++ b/assets/logo-playgen-birthday.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 180">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -10 420 190">
   <rect x="20" y="60" width="160" height="110" rx="24" fill="#1E64B5"/>
   <path d="M110 115 85 95 85 145Z" fill="#ffffff"/>
   <path d="M130 115 105 95 105 145Z" fill="#ffffff" opacity="0.75"/>


### PR DESCRIPTION
## Summary
- expand the logo SVG viewBox to include the negative y range used by the balloon path
- prevent the top of the logo graphic from being clipped when rendered

## Testing
- not run (static asset change)


------
https://chatgpt.com/codex/tasks/task_e_68d3e8eeeb6883278f1bfcedc36ffaee