### PR TITLE
Remove header text next to logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,11 +45,7 @@
     }
     .nav{display:flex;align-items:center;justify-content:space-between;padding:14px 0}
     .brand{display:flex;align-items:center;gap:12px;font-weight:800;letter-spacing:.4px}
-    .logo{
-      width:40px;height:40px;border-radius:12px;
-      background: conic-gradient(from 180deg, var(--accent), var(--accent2), var(--accent));
-      box-shadow: 0 8px 24px rgba(124,92,255,.45), inset 0 0 18px rgba(255,255,255,.2);
-    }
+    .brand-logo{height:144px;width:auto;display:block}
     .actions{display:flex;gap:10px;align-items:center}
     .btn{
       display:inline-flex;align-items:center;justify-content:center;gap:8px;
@@ -130,13 +126,7 @@
 <body>
 <header>
 <div class="container nav">
-<div class="brand"><img alt="Playgen Birthday Logo" src="logo.png" style="height:48px;"/>
-
-<div>
-<div style="font-size:14px;color:var(--muted);font-weight:700;letter-spacing:.08em">AI PRANK</div>
-<div style="font-size:18px;font-weight:900;">VIDEO ČESTITKE</div>
-</div>
-</div>
+<div class="brand"><img alt="Playgen Birthday Logo" class="brand-logo" src="logo.png"/></div>
 <div class="actions">
 <a class="btn" href="#kategorije">Kategorije</a>
 <a class="btn" href="#cenovnik">Cenovnik</a>


### PR DESCRIPTION
## Summary
- remove the AI PRANK / VIDEO ČESTITKE copy next to the header logo so only the logo remains
- enlarge the header logo to triple its previous height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d40f1cdb348327bf05b2d23d552dec