### PR TITLE
Remove VIP and Specijal categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,6 @@
 <span class="chip">Za ekipu (prank)</span>
 <span class="chip">Za decu</span>
 <span class="chip">Ljubavne</span>
-<span class="chip">VIP / Biznis</span>
 </div>
 <p class="muted" style="margin-top:10px">Sve se radi diskretno i po meri. Ti biraš ton (satirično, toplo, romantično, totalni prank) – mi isporučujemo.</p>
 </div>
@@ -180,20 +179,10 @@
 <img alt="Ljubavne čestitke" src="https://images.unsplash.com/photo-1529156069898-49953e39b3ac?q=80&amp;w=1200&amp;auto=format&amp;fit=crop"/>
 <div class="title">Ljubavne</div>
 </div>
-<div class="card" data-video="https://www.youtube.com/embed/2vjPBrBU-TM">
-<span class="tag">Biznis</span>
-<img alt="Biznis / VIP" src="https://images.unsplash.com/photo-1497366216548-37526070297c?q=80&amp;w=1200&amp;auto=format&amp;fit=crop"/>
-<div class="title">VIP / Biznis</div>
-</div>
 <div class="card" data-video="https://www.youtube.com/embed/9bZkp7q19f0">
 <span class="tag">Rođaci</span>
 <img alt="Porodične čestitke" src="https://images.unsplash.com/photo-1520975922322-261c3b95a87b?q=80&amp;w=1200&amp;auto=format&amp;fit=crop"/>
 <div class="title">Porodično</div>
-</div>
-<div class="card" data-video="https://www.youtube.com/embed/3JZ_D3ELwOQ">
-<span class="tag">Specijal</span>
-<img alt="Specijalne čestitke" src="https://images.unsplash.com/photo-1542353436-312f0ce1c8b9?q=80&amp;w=1200&amp;auto=format&amp;fit=crop"/>
-<div class="title">Specijal</div>
 </div>
 </div>
 </section>


### PR DESCRIPTION
## Summary
- remove the VIP / Biznis chip from the hero highlights
- drop the VIP / Biznis and Specijal cards from the categories grid

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d41addbec48327aa6095888c0b2388