### PR TITLE
Fix client counter to stay at 112

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
 <div class="section-title" style="margin:0 0 6px">Broj srećnih klijenata</div>
 <div
   data-base-count="112"
-  data-daily-increment="15"
+  data-daily-increment="0"
   data-start-date="2024-08-01"
   id="counter"
   style="font-size:54px;font-weight:900"
@@ -365,8 +365,13 @@
       const el = document.getElementById('counter');
       if(!el) return;
 
-      const baseCount = Number(el.dataset.baseCount) || 112;
-      const dailyIncrement = Number(el.dataset.dailyIncrement) || 15;
+      const toNumberOr = (value, fallback) => {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : fallback;
+      };
+
+      const baseCount = toNumberOr(el.dataset.baseCount, 112);
+      const dailyIncrement = toNumberOr(el.dataset.dailyIncrement, 15);
       const startDateValue = el.dataset.startDate;
       const formatter = new Intl.NumberFormat('sr-RS');
       const MS_PER_DAY = 86400000;


### PR DESCRIPTION
## Summary
- set the "Broj srećnih klijenata" counter to a zero daily increment so it remains at 112
- ensure the counter script respects zero and invalid dataset values when parsing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d42644b5e4832785d37f7d721ad041