### PR TITLE
Create order page with payment instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
 <div class="actions">
 <a class="btn" href="#kategorije">Kategorije</a>
 <a class="btn" href="#cenovnik">Cenovnik</a>
-<button class="btn btn-primary" id="orderTop">Poruči</button>
+<a class="btn btn-primary" href="order.html">Poruči</a>
 </div>
 </div>
 </header>
@@ -235,7 +235,7 @@
 <li>1 runda sitnih izmena</li>
 <li>Isporuka do 72h</li>
 </ul>
-<button class="btn" onclick="openOrder()">Poruči START</button>
+<a class="btn" href="order.html">Poruči START</a>
 </div>
 <div class="price-card highlight">
 <div class="muted">PRO (Najpopularniji)</div>
@@ -246,7 +246,7 @@
 <li>2 runde sitnih izmena</li>
 <li>Isporuka do 48h</li>
 </ul>
-<button class="btn btn-primary" onclick="openOrder()">Poruči PRO</button>
+<a class="btn btn-primary" href="order.html">Poruči PRO</a>
 </div>
 <div class="price-card">
 <div class="muted">VIP</div>
@@ -257,7 +257,7 @@
 <li>Ekspres (24h)</li>
 <li>Prioritetna podrška</li>
 </ul>
-<button class="btn" onclick="openOrder()">Poruči VIP</button>
+<a class="btn" href="order.html">Poruči VIP</a>
 </div>
 </div>
 </section>
@@ -286,7 +286,7 @@
 <h2 class="section-title" style="margin:0">Spremni? Naručite u 3 laka koraka</h2>
 <div class="muted">Klikni “Poruči”, plati na Payoneer ili račun — mi te kontaktiramo istog dana.</div>
 </div>
-<button class="btn btn-primary" onclick="openOrder()">Poruči sada</button>
+<a class="btn btn-primary" href="order.html">Poruči sada</a>
 </div>
 </div>
 </section>
@@ -308,52 +308,6 @@
 <div class="modal-body">
 <div class="ytbox">
 <iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="" frameborder="0" height="100%" id="ytFrame" src="" title="YouTube video player" width="100%"></iframe>
-</div>
-</div>
-</div>
-</div>
-<!-- Modal: Order & Payment -->
-<div class="modal-overlay" id="orderModal">
-<div class="modal">
-<header class="container" style="padding:14px 16px 0">
-<button class="close" onclick="closeOrder()">Zatvori ✕</button>
-</header>
-<div class="modal-body">
-<div class="container">
-<h3 class="section-title" style="margin-top:0">Uplata &amp; instrukcije</h3>
-<div class="order-grid">
-<div class="panel">
-<strong>1) Payoneer (preporučeno — najbrže)</strong>
-<p>Pošaljite iznos odabrane paketa na naš Payoneer nalog:</p>
-<ul class="list">
-<li>Account email: <span class="kbd">pay@vasdomen.com</span></li>
-<li>Account name: <span class="kbd">Vas Brend d.o.o.</span></li>
-<li>Opis/Reference: <span class="kbd">"Cestitka — Ime slavljenika"</span></li>
-</ul>
-<p class="note">*Po uplati, obavezno sačuvajte potvrdu (screenshot ili PDF).</p>
-</div>
-<div class="panel">
-<strong>2) Bankovni račun (SEPA/SRB)</strong>
-<ul class="list">
-<li>Primalac: <span class="kbd">Vas Brend d.o.o.</span></li>
-<li>IBAN: <span class="kbd">RS00 0000 0000 0000 0000 00</span></li>
-<li>SWIFT/BIC: <span class="kbd">XXXXRSBG</span></li>
-<li>Svrha uplate: <span class="kbd">"Cestitka — Ime slavljenika"</span></li>
-</ul>
-<p class="note">*Međunarodne provizije snosi nalogodavac.</p>
-</div>
-</div>
-<div class="panel" style="margin-top:16px">
-<strong>3) Pošaljite nam detalje</strong>
-<p>Posle uplate, pošaljite email na <a href="mailto:orders@vasdomen.com">orders@vasdomen.com</a> sa sledećim:</p>
-<ol class="list">
-<li>Potvrda uplate (screenshot ili PDF).</li>
-<li>Kratak opis slavljenika (ime, nadimci, zanimljivosti, interni fore).</li>
-<li>Ton videa (prank, toplo, romantično…), jezik, i željena dužina.</li>
-<li>Deadline (ako postoji) i format isporuke (MP4, link, itd.).</li>
-</ol>
-<p class="note">Kontaktiraćemo vas u roku od 12h od prijema poruke (radnim danima).</p>
-</div>
 </div>
 </div>
 </div>
@@ -424,28 +378,23 @@
       });
     });
     function closeVideo(){
+      if(!videoModal) return;
       ytFrame.src = '';
       videoModal.style.display = 'none';
     }
 
-    // Order modal
-    const orderModal = document.getElementById('orderModal');
-    function openOrder(){ orderModal.style.display='flex'; }
-    function closeOrder(){ orderModal.style.display='none'; }
-    document.getElementById('orderTop').addEventListener('click', openOrder);
-
     // Escape to close modals
     window.addEventListener('keydown', (e)=>{
       if(e.key === 'Escape'){
-        closeVideo(); closeOrder();
+        closeVideo();
       }
     });
     // Click outside
-    [videoModal, orderModal].forEach(modal => {
-      modal.addEventListener('click', (e)=>{
-        if(e.target === modal){ modal.style.display = 'none'; ytFrame.src=''; }
+    if(videoModal){
+      videoModal.addEventListener('click', (e)=>{
+        if(e.target === videoModal){ videoModal.style.display = 'none'; ytFrame.src=''; }
       });
-    });
+    }
   </script>
 </body>
 </html>

--- a/order.html
+++ b/order.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="sr">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Instrukcije za uplatu</title>
+  <style>
+    :root {
+      --purple: #7c5cff;
+      --orange: #ff7a45;
+      --bg: #0b0b10;
+      --text-dark: #1b1d29;
+      --muted: #5a6072;
+      --radius: 20px;
+      --shadow: 0 28px 60px rgba(10, 8, 38, 0.18);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      background:
+        radial-gradient(1200px 600px at 10% -10%, rgba(124, 92, 255, 0.18), transparent 60%),
+        radial-gradient(1000px 600px at 90% -20%, rgba(255, 122, 69, 0.16), transparent 60%),
+        var(--bg);
+      color: var(--text-dark);
+      padding: 32px 16px;
+    }
+
+    .card {
+      width: min(520px, 100%);
+      background: #ffffff;
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      padding: clamp(28px, 5vw, 42px);
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(26px, 5vw, 34px);
+      color: var(--text-dark);
+      line-height: 1.2;
+    }
+
+    p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 16px;
+      line-height: 1.6;
+    }
+
+    .account-box {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+      margin-top: 8px;
+    }
+
+    .account-input {
+      flex: 1 1 240px;
+      padding: 14px 16px;
+      border-radius: 14px;
+      border: 1px solid rgba(10, 11, 28, 0.12);
+      background: #f9f9fc;
+      font-weight: 600;
+      font-size: 16px;
+      letter-spacing: 0.5px;
+      color: var(--text-dark);
+    }
+
+    .account-input:focus {
+      outline: none;
+      border-color: rgba(124, 92, 255, 0.6);
+      box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.18);
+    }
+
+    .copy-btn {
+      flex: 0 0 auto;
+      padding: 14px 20px;
+      border: none;
+      border-radius: 14px;
+      background: linear-gradient(135deg, var(--purple), var(--orange));
+      color: #ffffff;
+      font-weight: 700;
+      font-size: 15px;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: 0 16px 30px rgba(124, 92, 255, 0.26);
+    }
+
+    .copy-btn:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 20px 36px rgba(124, 92, 255, 0.32);
+    }
+
+    .copy-btn:active {
+      transform: translateY(0);
+    }
+
+    .hint {
+      font-size: 15px;
+      color: var(--muted);
+    }
+
+    .notice {
+      display: none;
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--purple);
+    }
+
+    .notice.show {
+      display: block;
+      animation: fade-in 0.3s ease;
+    }
+
+    @keyframes fade-in {
+      from {
+        opacity: 0;
+        transform: translateY(-4px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .back-link {
+      margin-top: 12px;
+      text-decoration: none;
+      color: var(--purple);
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .back-link:hover {
+      color: var(--orange);
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Instrukcije za uplatu</h1>
+    <p>Da biste naručili svoju video čestitku, uplatite iznos na sledeći račun:</p>
+
+    <div>
+      <div class="account-box">
+        <input
+          class="account-input"
+          id="accountNumber"
+          type="text"
+          value="160-123456789-12, Raiffeisen banka"
+          readonly
+        />
+        <button class="copy-btn" id="copyBtn" type="button">Kopiraj broj računa</button>
+      </div>
+      <div class="notice" id="copyNotice">Broj računa je kopiran!</div>
+    </div>
+
+    <div class="hint">U polje svrha uplate unesite ime slavljenika.</div>
+    <div class="hint">Nakon uplate, pošaljite potvrdu na: <a href="mailto:info@playgen.com">info@playgen.com</a></div>
+
+    <a class="back-link" href="index.html">⬅ Povratak na početnu stranicu</a>
+  </div>
+
+  <script>
+    const copyButton = document.getElementById('copyBtn');
+    const accountInput = document.getElementById('accountNumber');
+    const notice = document.getElementById('copyNotice');
+
+    function showNotice() {
+      notice.classList.add('show');
+      clearTimeout(showNotice.timeout);
+      showNotice.timeout = setTimeout(() => {
+        notice.classList.remove('show');
+      }, 2400);
+    }
+
+    async function copyToClipboard() {
+      const text = accountInput.value;
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        try {
+          await navigator.clipboard.writeText(text);
+          showNotice();
+          return;
+        } catch (error) {
+          // fallback below
+        }
+      }
+
+      accountInput.select();
+      accountInput.setSelectionRange(0, text.length);
+      const successful = document.execCommand('copy');
+      if (successful) {
+        showNotice();
+      }
+      window.getSelection().removeAllRanges();
+    }
+
+    copyButton.addEventListener('click', copyToClipboard);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated `order.html` page with copy-to-clipboard account details and modern styling
- point all "Poruči" actions on the landing page to the new order page
- remove the legacy modal with Payoneer/bank instructions from the index page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d42d2e10a48327b647931a255665a2